### PR TITLE
Update _index.md

### DIFF
--- a/content/docs/modules/week2/webdata-for-dummies/_index.md
+++ b/content/docs/modules/week2/webdata-for-dummies/_index.md
@@ -19,7 +19,7 @@ bookHidden: true
 
 ## Prerequisites
 
-* Basic Python skills, for example by working through the [Python Bootcamp](/docs/modules/weeb1/pythonbootcamp/).
+* Basic Python skills, for example by working through the [Python Bootcamp](/docs/modules/week1/pythonbootcamp/).
 
 {{% hint info %}}
 __Downloading to and starting the tutorial on your computer__


### PR DESCRIPTION
Typo in weblink (8)

Changed link from (/docs/modules/weeb1/pythonbootcamp/) to (/docs/modules/week1/pythonbootcamp/)